### PR TITLE
feat: document that only `en_US` locale is support with Linux kernel terminal

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ This does not cover:
 
 - EBCDIC
 - Exotic custom fonts
+- Other locales than `en_US` for the following terminals: Linux console (kernel)
 
 # List of characters
 


### PR DESCRIPTION
Fixes #3.

@michaelerule, please feel free to review this!